### PR TITLE
Auids testing

### DIFF
--- a/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
@@ -185,8 +185,8 @@ class Aus
         foreach($propNames as $name) {
             $auKey .= '&' . $name . '~' . $this->getAuProperty($name, true);
         }
-
-        return $pluginKey . $auKey;
+        $this->auid = $pluginKey . $auKey;
+        return $this->auid;
     }
 
     /**

--- a/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
@@ -177,6 +177,10 @@ class Aus
      */
     public function generateAuid() {
         $plugin = $this->getPlugin();
+        if($plugin === null) {
+            $this->auid = null;
+            return null;
+        }
         $pluginKey = str_replace('.', '|', $plugin->getPluginIdentifier());
         $auKey = '';
         $propNames = $plugin->getDefinitionalProperties();

--- a/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Entity/Aus.php
@@ -167,7 +167,7 @@ class Aus
             $char = ord($matches[0]);
             return '%' . strtoupper(sprintf("%02x", $char));
         };
-        return preg_replace_callback('/[^_*a-zA-Z0-9]/', $callback, $value);
+        return preg_replace_callback('/[^-_*a-zA-Z0-9]/', $callback, $value);
     }
 
     /**

--- a/src/LOCKSSOMatic/CRUDBundle/Resources/config/doctrine/Aus.orm.yml
+++ b/src/LOCKSSOMatic/CRUDBundle/Resources/config/doctrine/Aus.orm.yml
@@ -54,7 +54,7 @@ LOCKSSOMatic\CRUDBundle\Entity\Aus:
             comment: 'Should LOCKSSOMatic manage this PLN.'
         auid:            
             type: string
-            length: 255
+            length: 2048
             nullable: true
             comment: 'The LOCKSS auId. @todo: Explain where this is generated.'
         manifestUrl:

--- a/src/LOCKSSOMatic/DefaultBundle/Command/PurgeCommand.php
+++ b/src/LOCKSSOMatic/DefaultBundle/Command/PurgeCommand.php
@@ -44,7 +44,7 @@ class PurgeCommand extends ContainerAwareCommand
      */
     protected function configure()
     {
-        $this->setName('lom:purge')
+        $this->setName('lockssomatic:purge')
                 ->setDescription('Purge *ALL* data from the database.');
     }
 

--- a/src/LOCKSSOMatic/LoggingBundle/Command/ExportLogsCommand.php
+++ b/src/LOCKSSOMatic/LoggingBundle/Command/ExportLogsCommand.php
@@ -45,7 +45,7 @@ class ExportLogsCommand extends ContainerAwareCommand
      */
     protected function configure()
     {
-        $this->setName('lom:export:logs')
+        $this->setName('lockssomatic:export:logs')
             ->setDescription('Export logs from the database for archiving.')
             ->addArgument('file', InputArgument::REQUIRED,
                 'File to write the logs to.')

--- a/src/LOCKSSOMatic/PLNImporterBundle/Command/GenerateAuidsCommand.php
+++ b/src/LOCKSSOMatic/PLNImporterBundle/Command/GenerateAuidsCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LOCKSSOMatic\PLNImporterBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Description of GenerateAuids
+ *
+ * @author Michael Joyce <michael@negativespace.net>
+ */
+class GenerateAuidsCommand extends ContainerAwareCommand
+{
+
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        parent::setContainer($container);
+        $this->em = $container->get('doctrine')->getManager();
+    }
+
+    public function configure()
+    {
+        $this->setName('lockssomatic:auids')
+            ->setDescription('Import PLN titledb file.');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->em->getConnection()->getConfiguration()->setSQLLogger(null);
+        $this->getContainer()->get('activity_log')->disable();
+        $repo = $this->em->getRepository('LOCKSSOMaticCRUDBundle:Aus');
+        $dql = 'SELECT a FROM LOCKSSOMaticCRUDBundle:Aus a WHERE a.auid IS NULL';
+        $query = $this->em->createQuery($dql);
+        $iterator = $query->iterate();
+        $n = 0;
+
+        $iterator->next();
+        while ($iterator->valid() && $row = $iterator->current()) {
+            $iterator->next();
+            // force doctrine to refetch the au. flush() and clear() are causing
+            // problems with entity relationships and refresh() was broken. So
+            // this hack is necessary.
+            $au = $repo->find($row[0]->getId());
+            $au->generateAuid();
+            $n++;
+            if($n % 100 === 0) {
+                $this->progressReport($output, $n);
+            }
+        }
+        $this->em->flush();
+        $output->writeln("processed {$n} aus");
+        $this->getContainer()->get('activity_log')->enable();
+    }
+
+    public function progressReport(OutputInterface $output, $n)
+    {
+        $this->em->flush();
+        $this->em->clear();
+        gc_collect_cycles();
+        $output->writeln("$n - " . sprintf('%dM', memory_get_usage() / (1024 * 1024)) . '/' . ini_get('memory_limit'));
+    }
+
+}

--- a/src/LOCKSSOMatic/PLNImporterBundle/Command/PLNTitledbImportCommand.php
+++ b/src/LOCKSSOMatic/PLNImporterBundle/Command/PLNTitledbImportCommand.php
@@ -1,7 +1,5 @@
 <?php
 
-// src/LOCKSSOMatic/PLNImporterBundle/Command/PLNTitledbImportCommand.php
-
 namespace LOCKSSOMatic\PLNImporterBundle\Command;
 
 use Doctrine\Common\Util\Debug;
@@ -179,7 +177,6 @@ class PLNTitledbImportCommand extends ContainerAwareCommand
         $this->getContentOwner($publisherName, $plugin);
 
         $aus = new Aus();
-        $aus->setAuid('command-imported');
         $aus->setComment('AU created by import command');
         $aus->setManifestUrl('http://example.com/manifest/url');
         $plugin->addAus($aus);        


### PR DESCRIPTION
Test the AUid generation code against actual live AUids from a lockss box.

Requires a database schema update. Does not require composer update.

Backwards incompatible change: the lom:* commands have been renamed to lockssomatic:* for consistency with the commands already present. lom:purge is now lockssomatic:purge and lom:export:logs is now lockssomatic:export:logs.