### PR TITLE
Export manifests

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,3 +34,7 @@ parameters:
 
     # Number of AUs per titledb.xml file
     lockss_aus_per_titledb: 50
+
+    # Number of URLs per manifest file
+    lockss_urls_per_manifest: 500
+

--- a/src/LOCKSSOMatic/CrudBundle/Entity/Content.php
+++ b/src/LOCKSSOMatic/CrudBundle/Entity/Content.php
@@ -190,7 +190,9 @@ class Content implements GetPlnInterface
      */
     public function setSize($size)
     {
-        $this->size = $size;
+        if($size !== '') {
+            $this->size = $size;
+        }
 
         return $this;
     }

--- a/src/LOCKSSOMatic/CrudBundle/Entity/ContentProvider.php
+++ b/src/LOCKSSOMatic/CrudBundle/Entity/ContentProvider.php
@@ -4,6 +4,7 @@ namespace LOCKSSOMatic\CrudBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -425,11 +426,25 @@ class ContentProvider implements GetPlnInterface
     /**
      * Get deposits
      *
-     * @return Deposit[]
+     * @return ArrayCollection|Deposit[]
      */
     public function getDeposits()
     {
         return $this->deposits;
+    }
+
+    /**
+     * @return Content
+     */
+    public function getContent() {
+        $contentList = array();
+        foreach($this->deposits as $deposit) {
+            $content = $deposit->getContent();
+            if($content !== null && count($content) > 0) {
+                $contentList = array_merge($contentList, $content->toArray());
+            }
+        }
+        return $contentList;
     }
 
     /**

--- a/src/LOCKSSOMatic/CrudBundle/Entity/Deposit.php
+++ b/src/LOCKSSOMatic/CrudBundle/Entity/Deposit.php
@@ -248,10 +248,14 @@ class Deposit implements GetPlnInterface
         $this->content->removeElement($content);
     }
 
+    public function countContent() {
+        return $this->content->count();
+    }
+
     /**
      * Get deposits
      *
-     * @return Collection
+     * @return ArrayCollection|Content[]
      */
     public function getContent()
     {

--- a/src/LOCKSSOMatic/CrudBundle/Entity/Pln.php
+++ b/src/LOCKSSOMatic/CrudBundle/Entity/Pln.php
@@ -303,12 +303,20 @@ class Pln
      * @param type $name
      * @return PlnProperty
      */
-    public function getProperty($name)
+    public function getProperty($name, $asList = false)
     {
+        $properties = array();
+
         foreach ($this->getPlnProperties() as $prop) {
             if ($prop->getPropertyKey() === $name) {
-                return $prop;
+                $properties[] = $prop;
             }
+        }
+        if($asList) {
+            return $properties;
+        }
+        if(count($properties) > 0) {
+            return $properties[0];
         }
         return null;
     }

--- a/src/LOCKSSOMatic/CrudBundle/Entity/Plugin.php
+++ b/src/LOCKSSOMatic/CrudBundle/Entity/Plugin.php
@@ -324,7 +324,7 @@ class Plugin
     /**
      * Convenience method. Get the definitional plugin parameter names
      *
-     * @return array
+     * @return ArrayCollection|PluginProperty[]
      */
     public function getDefinitionalProperties()
     {
@@ -434,10 +434,10 @@ class Plugin
     /**
      * Add plns
      *
-     * @param \LOCKSSOMatic\CrudBundle\Entity\Pln $plns
+     * @param Pln $plns
      * @return Plugin
      */
-    public function addPln(\LOCKSSOMatic\CrudBundle\Entity\Pln $plns)
+    public function addPln(Pln $plns)
     {
         $this->plns[] = $plns;
 
@@ -447,9 +447,9 @@ class Plugin
     /**
      * Remove plns
      *
-     * @param \LOCKSSOMatic\CrudBundle\Entity\Pln $plns
+     * @param Pln $plns
      */
-    public function removePln(\LOCKSSOMatic\CrudBundle\Entity\Pln $plns)
+    public function removePln(Pln $plns)
     {
         $this->plns->removeElement($plns);
     }
@@ -457,7 +457,7 @@ class Plugin
     /**
      * Get plns
      *
-     * @return \Doctrine\Common\Collections\Collection 
+     * @return Collection
      */
     public function getPlns()
     {

--- a/src/LOCKSSOMatic/CrudBundle/Form/ContentProviderType.php
+++ b/src/LOCKSSOMatic/CrudBundle/Form/ContentProviderType.php
@@ -8,6 +8,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ContentProviderType extends AbstractType
 {
+
     /**
      * @param FormBuilderInterface $builder
      * @param array $options
@@ -15,21 +16,38 @@ class ContentProviderType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('uuid', 'text', array(
+            ->add('uuid', 'text',
+                array(
                 'required' => false,
+                'attr'     => array(
+                    'help' => 'Leave UUID blank to have one generated.'
+            )))
+            ->add('permissionurl', 'url',
+                array(
+                'label' => 'Permission URL',
+                'attr'  => array(
+                    'help' => 'URL for the LOCKSS permission statement.'
+                )
+            ))
+            ->add('name')
+            ->add('maxFileSize', 'integer',
+                array(
                 'attr' => array(
-                'help' => 'Leave UUID blank to have one generated.'
-                )))
-                ->add('permissionurl')
-                ->add('name')
-                ->add('maxFileSize')
-                ->add('maxAuSize')
-                ->add('contentOwner')
-                ->add('plugin')
-                ->add('pln')
-                ;
+                    'help' => 'Maximum file size allowed in an AU, in kb (1,000 bytes)'
+                )
+            ))
+            ->add('maxAuSize', 'integer',
+                array(
+                'attr' => array(
+                    'help' => 'Maximum AU size, in kb (1,000 bytes)'
+                )
+            ))
+            ->add('contentOwner')
+            ->add('plugin')
+            ->add('pln')
+        ;
     }
-    
+
     /**
      * @param OptionsResolverInterface $resolver
      */
@@ -47,4 +65,5 @@ class ContentProviderType extends AbstractType
     {
         return 'lockssomatic_crudbundle_contentprovider';
     }
+
 }

--- a/src/LOCKSSOMatic/CrudBundle/Resources/views/ContentProvider/show.html.twig
+++ b/src/LOCKSSOMatic/CrudBundle/Resources/views/ContentProvider/show.html.twig
@@ -30,24 +30,33 @@
                 <td>{{ entity.uuid }}</td>
             </tr>
             <tr>
-                <th>Permissionurl</th>
-                <td>{{ entity.permissionurl }}</td>
+                <th>Permission url</th>
+                <td><a href="{{ entity.permissionurl }}">{{ entity.permissionurl }}</a></td>
             </tr>
             <tr>
                 <th>Name</th>
                 <td>{{ entity.name }}</td>
             </tr>
             <tr>
-                <th>Maxfilesize</th>
+                <th>Max file size</th>
                 <td>{{ entity.maxFileSize }}</td>
             </tr>
             <tr>
-                <th>Maxausize</th>
+                <th>Max au size</th>
                 <td>{{ entity.maxAuSize }}</td>
+            </tr>
+            <tr>
+                <th>Content Owner</th>
+                <td><a href="{{ path('contentowner_show', {'id': entity.contentOwner.id}) }}">{{ entity.contentOwner.name }}</a></td>
+            </tr>
+            <tr>
+                <th>PLN</th>
+                <td><a href="{{ path('pln_show', {'id': entity.pln.id}) }}">{{ entity.pln.name }}</a></td>
             </tr>
             <tr>
                 <th>LOCKSS Plugin</th>
                 <td><a href="{{ path('plugin_show', {'id': entity.plugin.id}) }}">{{ entity.plugin.name }}</a></td>
+            </tr>
         </tbody>
     </table>
 {% endblock %}

--- a/src/LOCKSSOMatic/CrudBundle/Service/ContentBuilder.php
+++ b/src/LOCKSSOMatic/CrudBundle/Service/ContentBuilder.php
@@ -93,33 +93,21 @@ class ContentBuilder
         return $content;
     }
 
-    private function fieldOrNull($row, $headerIdx, $field)
-    {
-        if (! array_key_exists($field, $headerIdx)) {
-            return null;
-        }
-        $index = $headerIdx[$field];
-        if (! array_key_exists($index, $row)) {
-            return null;
-        }
-        return $row[$index];
-    }
-
-    public function fromArray($row, $headerIdx)
+    public function fromArray($record)
     {
         $content = new Content();
-        $content->setSize($this->fieldOrNull($row, $headerIdx, 'size'));
-        $content->setChecksumType($this->fieldOrNull($row, $headerIdx, 'checksum type'));
-        $content->setChecksumValue($this->fieldOrNull($row, $headerIdx, 'checksum value'));
-        $content->setUrl($row[$headerIdx['url']]);
+        $content->setSize($record['size']);
+        $content->setChecksumType($record['checksum type']);
+        $content->setChecksumValue($record['checksum value']);
+        $content->setUrl($record['url']);
         $content->setRecrawl(true);
         $content->setTitle("Generated Title");
         if ($this->em !== null) {
             $this->em->persist($content);
         }
         
-        foreach (array_keys($headerIdx) as $key) {
-            $this->buildProperty($content, $key, $this->fieldOrNull($row, $headerIdx, $key));
+        foreach (array_keys($record) as $key) {
+            $this->buildProperty($content, $key, $record[$key]);
         }
         return $content;
     }

--- a/src/LOCKSSOMatic/ImportExportBundle/Resources/views/Configs/manifest.html.twig
+++ b/src/LOCKSSOMatic/ImportExportBundle/Resources/views/Configs/manifest.html.twig
@@ -1,0 +1,12 @@
+<html>
+    <title>LOCKSSOMatic Manifest Page</title>
+    <body>
+        <h1>LOCKSSOMatic Manifest Page</h1>
+        <ul>
+            {% for item in content %}
+                <li><a href="{{ item.url }}">{{ item.url }}</a></li>
+                {% endfor %}
+        </ul>
+        LOCKSS system has permission to collect, preserve, and serve this Archival Unit
+    </body>
+</html>

--- a/src/LOCKSSOMatic/SwordBundle/Controller/SwordController.php
+++ b/src/LOCKSSOMatic/SwordBundle/Controller/SwordController.php
@@ -197,7 +197,6 @@ class SwordController extends Controller
 
         $permissionHost = $provider->getPermissionHost();
         foreach ($atomEntry->xpath('//lom:content') as $content) {
-            $this->get('logger')->error((string) ($content));
             // check required properties.
             $this->precheckContentProperties($content, $plugin);
             $url = trim((string) $content);

--- a/src/LOCKSSOMatic/SwordBundle/Listener/SwordErrorListener.php
+++ b/src/LOCKSSOMatic/SwordBundle/Listener/SwordErrorListener.php
@@ -80,6 +80,10 @@ class SwordErrorListener
     {
         $exception = $event->getException();
 
+        if( ! $this->controller[0] instanceof SwordController) {
+            return;
+        }
+
         if ($exception instanceof ApiException) {
             $response = new Response();
             $response->headers->add($exception->getHeaders());
@@ -99,22 +103,20 @@ class SwordErrorListener
             return;
         }
         
-        if ($this->controller[0] instanceof SwordController) {
-            $response = new Response();
-            $response->headers->set('Content-Type', 'text/xml');
-            $response->setStatusCode(500);
-            $response->setContent($this->templating->render(
-                'LOCKSSOMaticSwordBundle:Sword:exceptionDocument.xml.twig',
-                array(
-                    'errorUri' => '',
-                    'statusCode' => 500,
-                    'message' => $exception->getMessage(),
-                    'trace' => $exception->getTraceAsString(),
-                )
-            ));
-            $event->setResponse($response);
-            return;
-        }
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/xml');
+        $response->setStatusCode(500);
+        $response->setContent($this->templating->render(
+            'LOCKSSOMaticSwordBundle:Sword:exceptionDocument.xml.twig',
+            array(
+                'errorUri' => '',
+                'statusCode' => 500,
+                'message' => $exception->getMessage(),
+                'trace' => $exception->getTraceAsString(),
+            )
+        ));
+        $event->setResponse($response);
+        return;
     }
 
     /**

--- a/src/LOCKSSOMatic/UserBundle/Command/ActivateUserCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/ActivateUserCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ */
+class ActivateUserCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:activate')
+            ->setDescription('Activate a user')
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+            ))
+            ->setHelp(<<<EOT
+The <info>fos:user:activate</info> command activates a user (so they will be able to log in):
+
+  <info>php app/console fos:user:activate user@example.com</info>
+EOT
+            );
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+
+        $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
+        $manipulator->activate($username);
+
+        $output->writeln(sprintf('User "%s" has been activated.', $username));
+    }
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('username')) {
+            $username = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please choose a username:',
+                function($username) {
+                    if (empty($username)) {
+                        throw new \Exception('Username can not be empty');
+                    }
+
+                    return $username;
+                }
+            );
+            $input->setArgument('username', $username);
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/ChangePasswordCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/ChangePasswordCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ChangePasswordCommand
+ */
+class ChangePasswordCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:change-password')
+            ->setDescription('Change the password of a user.')
+            ->setDefinition(array(
+                new InputArgument('email', InputArgument::REQUIRED, 'The email'),
+                new InputArgument('password', InputArgument::REQUIRED, 'The password'),
+            ))
+            ->setHelp(<<<EOT
+The <info>fos:user:change-password</info> command changes the password of a user:
+
+  <info>php app/console fos:user:change-password user@example.com</info>
+
+This interactive shell will first ask you for a password.
+
+You can alternatively specify the password as a second argument:
+
+  <info>php app/console fos:user:change-password user@example.com mypassword</info>
+
+EOT
+            );
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $email = $input->getArgument('email');
+        $password = $input->getArgument('password');
+
+        $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
+        $manipulator->changePassword($email, $password);
+
+        $output->writeln(sprintf('Changed password for user <comment>%s</comment>', $email));
+    }
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('email')) {
+            $email = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please give the email:',
+                function($email) {
+                    if (empty($email)) {
+                        throw new \Exception('Username can not be empty');
+                    }
+
+                    return $email;
+                }
+            );
+            $input->setArgument('email', $email);
+        }
+
+        if (!$input->getArgument('password')) {
+            $password = $this->getHelper('dialog')->askHiddenResponseAndValidate(
+                $output,
+                'Please enter the new password:',
+                function($password) {
+                    if (empty($password)) {
+                        throw new \Exception('Password can not be empty');
+                    }
+
+                    return $password;
+                }
+            );
+            $input->setArgument('password', $password);
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/CreateUserCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/CreateUserCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Matthieu Bontemps <matthieu@knplabs.com>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Luis Cordova <cordoval@gmail.com>
+ */
+class CreateUserCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:create')
+            ->setDescription('Create a user.')
+            ->setDefinition(array(
+                new InputArgument('email', InputArgument::REQUIRED, 'The email'),
+                new InputArgument('password', InputArgument::REQUIRED, 'The password'),
+                new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Set the user as super admin'),
+                new InputOption('inactive', null, InputOption::VALUE_NONE, 'Set the user as inactive'),
+            ))
+            ->setHelp(<<<EOT
+The <info>fos:user:create</info> command creates a user:
+
+  <info>php app/console fos:user:create user@example.com</info>
+
+This interactive shell will ask you for a password.
+
+You can alternatively specify the email and password as the first and second arguments:
+
+  <info>php app/console fos:user:create matthieu@example.com mypassword</info>
+
+You can create a super admin via the super-admin flag:
+
+  <info>php app/console fos:user:create admin@example.com --super-admin</info>
+
+You can create an inactive user (will not be able to log in):
+
+  <info>php app/console fos:user:create user@example.com --inactive</info>
+
+EOT
+            );
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $email      = $input->getArgument('email');
+        $password   = $input->getArgument('password');
+        $inactive   = $input->getOption('inactive');
+        $superadmin = $input->getOption('super-admin');
+
+        $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
+        $manipulator->create($email, $password, $email, !$inactive, $superadmin);
+
+        $output->writeln(sprintf('Created user <comment>%s</comment>', $email));
+    }
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('email')) {
+            $email = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please choose an email:',
+                function($email) {
+                    if (empty($email)) {
+                        throw new \Exception('Email can not be empty');
+                    }
+
+                    return $email;
+                }
+            );
+            $input->setArgument('email', $email);
+        }
+
+        if (!$input->getArgument('password')) {
+            $password = $this->getHelper('dialog')->askHiddenResponseAndValidate(
+                $output,
+                'Please choose a password:',
+                function($password) {
+                    if (empty($password)) {
+                        throw new \Exception('Password can not be empty');
+                    }
+
+                    return $password;
+                }
+            );
+            $input->setArgument('password', $password);
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/DeactivateUserCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/DeactivateUserCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ */
+class DeactivateUserCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:deactivate')
+            ->setDescription('Deactivate a user')
+            ->setDefinition(array(
+                new InputArgument('email', InputArgument::REQUIRED, 'The user email address'),
+            ))
+            ->setHelp(<<<EOT
+The <info>fos:user:deactivate</info> command deactivates a user (will not be able to log in)
+
+  <info>php app/console fos:user:deactivate user@example.com</info>
+EOT
+            );
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $email = $input->getArgument('email');
+
+        $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
+        $manipulator->deactivate($email);
+
+        $output->writeln(sprintf('User "%s" has been deactivated.', $email));
+    }
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('email')) {
+            $email = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please choose a email:',
+                function($email) {
+                    if (empty($email)) {
+                        throw new \Exception('Username can not be empty');
+                    }
+
+                    return $email;
+                }
+            );
+            $input->setArgument('email', $email);
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/DemoteUserCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/DemoteUserCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use FOS\UserBundle\Util\UserManipulator;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+class DemoteUserCommand extends RoleCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('fos:user:demote')
+            ->setDescription('Demote a user by removing a role')
+            ->setHelp(<<<EOT
+The <info>fos:user:demote</info> command demotes a user by removing a role
+
+  <info>php app/console fos:user:demote user@example.com ROLE_CUSTOM</info>
+  <info>php app/console fos:user:demote --super user@example.com</info>
+EOT
+            );
+    }
+
+    protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $email, $super, $role)
+    {
+        if ($super) {
+            $manipulator->demote($email);
+            $output->writeln(sprintf('User "%s" has been demoted as a simple user.', $email));
+        } else {
+            if ($manipulator->removeRole($email, $role)) {
+                $output->writeln(sprintf('Role "%s" has been removed from user "%s".', $role, $email));
+            } else {
+                $output->writeln(sprintf('User "%s" didn\'t have "%s" role.', $email, $role));
+            }
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/PromoteUserCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/PromoteUserCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use FOS\UserBundle\Util\UserManipulator;
+
+/**
+ * @author Matthieu Bontemps <matthieu@knplabs.com>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Luis Cordova <cordoval@gmail.com>
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+class PromoteUserCommand extends RoleCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('fos:user:promote')
+            ->setDescription('Promotes a user by adding a role')
+            ->setHelp(<<<EOT
+The <info>fos:user:promote</info> command promotes a user by adding a role
+
+  <info>php app/console fos:user:promote user@example.com ROLE_CUSTOM</info>
+  <info>php app/console fos:user:promote --super user@example.com</info>
+EOT
+            );
+    }
+
+    protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $email, $super, $role)
+    {
+        if ($super) {
+            $manipulator->promote($email);
+            $output->writeln(sprintf('User "%s" has been promoted as a super administrator.', $email));
+        } else {
+            if ($manipulator->addRole($email, $role)) {
+                $output->writeln(sprintf('Role "%s" has been added to user "%s".', $role, $email));
+            } else {
+                $output->writeln(sprintf('User "%s" did already have "%s" role.', $email, $role));
+            }
+        }
+    }
+}

--- a/src/LOCKSSOMatic/UserBundle/Command/RoleCommand.php
+++ b/src/LOCKSSOMatic/UserBundle/Command/RoleCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LOCKSSOMatic\UserBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use FOS\UserBundle\Util\UserManipulator;
+
+/**
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+abstract class RoleCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('email', InputArgument::REQUIRED, 'The email'),
+                new InputArgument('role', InputArgument::OPTIONAL, 'The role'),
+                new InputOption('super', null, InputOption::VALUE_NONE, 'Instead specifying role, use this to quickly add the super administrator role'),
+            ));
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $email = $input->getArgument('email');
+        $role = $input->getArgument('role');
+        $super = (true === $input->getOption('super'));
+
+        if (null !== $role && $super) {
+            throw new \InvalidArgumentException('You can pass either the role or the --super option (but not both simultaneously).');
+        }
+
+        if (null === $role && !$super) {
+            throw new \RuntimeException('Not enough arguments.');
+        }
+
+        $manipulator = $this->getContainer()->get('fos_user.util.user_manipulator');
+        $this->executeRoleCommand($manipulator, $output, $email, $super, $role);
+    }
+
+    /**
+     * @see Command
+     *
+     * @param UserManipulator $manipulator
+     * @param OutputInterface $output
+     * @param string          $email
+     * @param boolean         $super
+     * @param string          $role
+     *
+     * @return void
+     */
+    abstract protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $email, $super, $role);
+
+    /**
+     * @see Command
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('email')) {
+            $email = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please choose a email:',
+                function($email) {
+                    if (empty($email)) {
+                        throw new \Exception('Username can not be empty');
+                    }
+
+                    return $email;
+                }
+            );
+            $input->setArgument('email', $email);
+        }
+        if ((true !== $input->getOption('super')) && !$input->getArgument('role')) {
+            $role = $this->getHelper('dialog')->askAndValidate(
+                $output,
+                'Please choose a role:',
+                function($role) {
+                    if (empty($role)) {
+                        throw new \Exception('Role can not be empty');
+                    }
+
+                    return $role;
+                }
+            );
+            $input->setArgument('role', $role);
+        }
+    }
+}


### PR DESCRIPTION
The export command now writes manifest files. It doesn't include them in the AU XML yet. 

Also includes:
 * override all the fos:user:* commands to use email address instead of username.
 * content url validation in CSV deposit upload
 * Content owner displays on the content provider page.

If you aren't cloning the repository from scratch, you will need to add `lockss_urls_per_manifest: 50` to the parameters.yml file (50 seemed like a good default, but so does 500).