### PR TITLE
Rethink the manifests stuff. They're connected to AUs, not to deposits

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,7 +34,3 @@ parameters:
 
     # Number of AUs per titledb.xml file
     lockss_aus_per_titledb: 50
-
-    # Number of URLs per manifest file
-    lockss_urls_per_manifest: 500
-

--- a/src/LOCKSSOMatic/ImportExportBundle/Command/ExportConfigsCommand.php
+++ b/src/LOCKSSOMatic/ImportExportBundle/Command/ExportConfigsCommand.php
@@ -2,6 +2,7 @@
 
 namespace LOCKSSOMatic\ImportExportBundle\Command;
 
+use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\EntityManager;
 use Exception;
 use LOCKSSOMatic\CrudBundle\Entity\Pln;
@@ -79,35 +80,28 @@ class ExportConfigsCommand extends ContainerAwareCommand {
 
     public function exportPlnConfig(Pln $pln, $dir) {
         $this->exportPlugins($pln, $dir);
-        $this->exportAuFiles($pln, $dir);
+        $auFiles = $this->exportAuFiles($pln, $dir);
         $this->exportManifests($pln, $dir);
+        $this->exportLockssXML($pln, $dir, $auFiles);
     }
 
     public function exportManifests(Pln $pln, $dir) {
         $twig = $this->getContainer()->get('templating');
         $manifestPath = "{$dir}/manifests";
         $this->fs->mkdir($manifestPath);
-        $limit = $this->getContainer()->getParameter('lockss_urls_per_manifest');
         foreach($pln->getContentProviders() as $provider) {
-
-            $content = $provider->getContent();
-            $contentCount = count($content);
-            if($contentCount === 0) {
-                continue;
-            }
-            $manifestFiles = ceil($contentCount / $limit);
-            $digits = ceil(log10($manifestFiles));
-
+            $aus = $provider->getAus();
             $providerPath = "{$manifestPath}/{$provider->getContentOwner()->getId()}/{$provider->getId()}";
             $this->fs->mkdir($providerPath);
-
-            for($i = 1; $i < $manifestFiles; $i++) {
-                $filename = sprintf("au_%0{$digits}d.html", $i);
-                $slice = array_slice($content, ($i-1) * $limit, $limit);
+            foreach($aus as $au) {
+                $content = $au->getContent();
+                if(count($content) === 0) {
+                    continue;
+                }
                 $html = $twig->render('LOCKSSOMaticImportExportBundle:Configs:manifest.html.twig', array(
-                    'content' => $slice
+                    'content' => $content
                 ));
-                file_put_contents("$providerPath/$filename", $html);
+                file_put_contents("{$providerPath}/au_{$au->getId()}.html", $html);
             }
         }
     }
@@ -117,6 +111,8 @@ class ExportConfigsCommand extends ContainerAwareCommand {
         $limit = $this->getContainer()->getParameter('lockss_aus_per_titledb');
         $titlePath = "{$dir}/titledbs";
         $this->fs->mkdir($titlePath);
+        $auFiles = array();
+        $auBuilder = $this->getContainer()->get('crud.builder.au');
         foreach($pln->getContentProviders() as $provider) {
             $aus = $provider->getAus();
             $auCount = $aus->count();
@@ -130,8 +126,20 @@ class ExportConfigsCommand extends ContainerAwareCommand {
             $providerPath = "{$titlePath}/{$provider->getContentOwner()->getId()}/{$provider->getId()}";
             $this->fs->mkdir($providerPath);
 
+            foreach($aus as $au) {
+                $manifestProp = $au->getAuProperty('manifest_url');
+                if($manifestProp === "") {
+                    $this->getContainer()->get('logger')->warn('Building manifest url for ' . $au->getId());
+                    $root = $au->getRootPluginProperties();
+                    $manifestProp = $auBuilder->buildProperty($au, 'param.manifest', null, $root[0]);
+                    $auBuilder->buildProperty($au, 'key', 'manifest_url', $manifestProp);
+                    $auBuilder->buildProperty($au, 'value', "manifests/{$provider->getContentOwner()->getId()}/{$provider->getId()}/au_{$au->getId()}.html", $manifestProp);
+                } 
+            }
+
             for($i = 1; $i <= $titleDbFiles; $i++) {
                 $filename = sprintf("titledb_%0{$digits}d.xml", $i);
+                $auFiles[] = "titleDbs/{$provider->getContentOwner()->getId()}/{$provider->getId()}/$filename";
                 $slice = array_slice($aus->toArray(), ($i-1) * $limit, $limit);
                 $xml = $twig->render('LOCKSSOMaticImportExportBundle:Configs:titledb.xml.twig', array(
                     'aus' => $slice,
@@ -139,6 +147,7 @@ class ExportConfigsCommand extends ContainerAwareCommand {
                 file_put_contents("$providerPath/$filename", $xml);
             }
         }
+        return $auFiles;
     }
 
     /**
@@ -155,26 +164,36 @@ class ExportConfigsCommand extends ContainerAwareCommand {
         foreach($plugins as $plugin) {
             copy($plugin->getPath(), $pluginPath . '/' . $plugin->getFilename());
         }
+        $twig = $this->getContainer()->get('templating');
+        $html = $twig->render('LOCKSSOMaticImportExportBundle:Configs:pluginList.html.twig', array(
+            'pln' => $pln
+        ));
+        file_put_contents("{$dir}/plugins/index.html", $html);
     }
 
-    public function exportLockssXML(Pln $pln, $path) {
+    public function exportLockssXML(Pln $pln, $dir, $auFiles) {
         $boxes = $pln->getBoxes();
         foreach ($boxes as $box) {
             $boxList[] = "{$box->getProtocol()}:[{$box->getIpAddress()}]:{$box->getPort()}";
         }
         $boxProp = $pln->getProperty('id.initialV3PeerList');
         if( ! $boxProp) {
-            throw new Exception("Cannot find id.initialV3PeerList in PLN properties.");
+            $this->logger->warning("Cannot find id.initialV3PeerList in PLN properties.");
         }
         $boxProp->setPropertyValue($boxList);
+
+        $titleProp = $pln->getProperty('titleDbs');
+        $titleProp->setPropertyValue($auFiles);
+
         $this->em->flush();
         $twig = $this->getContainer()->get('templating');
         $xml = $twig->render(
             'LOCKSSOMaticImportExportBundle:Configs:lockss.xml.twig', 
             array(
-                'entity' => $pln
-        ));
-        file_put_contents($path, $xml);
+                'pln' => $pln
+            )
+        );
+        file_put_contents("{$dir}/lockss.xml", $xml);
     }
 
 }

--- a/src/LOCKSSOMatic/ImportExportBundle/Command/PLNImportCommand.php
+++ b/src/LOCKSSOMatic/ImportExportBundle/Command/PLNImportCommand.php
@@ -80,9 +80,10 @@ class PLNImportCommand extends ContainerAwareCommand
 
         $xml = simplexml_load_file($input->getArgument('file'));
         $root = $xml->xpath('/lockss-config/property');
-        $this->importProperties($pln, $root[0]);        
-        $this->em->refresh($pln);
-        $this->importBoxes($pln);
+        $this->importProperties($pln, $root[0]);
+        $this->em->flush();
+        $this->em->clear();
+        $pln = $this->em->getRepository('LOCKSSOMaticCrudBundle:Pln')->find($id);        $this->importBoxes($pln);
 
         $this->em->flush();
         $activityLog->enable();
@@ -131,7 +132,7 @@ class PLNImportCommand extends ContainerAwareCommand
                     $property->setPropertyValue($this->getList($child));
                     break;
                 default:
-                    $this->logger->warning("(probably harmless): Unknown node name: {$child->getName()}");
+                    $this->logger->notice("(probably harmless): Unknown node name: {$child->getName()}");
             }
         }
     }

--- a/src/LOCKSSOMatic/ImportExportBundle/Resources/views/Configs/pluginList.html.twig
+++ b/src/LOCKSSOMatic/ImportExportBundle/Resources/views/Configs/pluginList.html.twig
@@ -7,7 +7,7 @@
         <h3>{{ pln.name }} Plugin Registry</h3>        
         <ul>
             {% for plugin in pln.plugins %}
-                <li><a href="{{ path('configs_plugin', {'plnId': pln.id, 'filename': plugin.filename}) }}">{{ plugin.filename }}</a></li>
+                <li><a href="{{ plugin.filename }}">{{ plugin.filename }}</a></li>
             {% endfor %}
         </ul>
         <p>


### PR DESCRIPTION
Rethink the manifests stuff. They're connected to AUs, not to deposits or to content.

Write one manifest per AU. There's no limit to how many content items
end up in an AU, so there's no limit to how many URLs end up in a
manifest.

Refactor the AuBuilder a little to add the provider's permission url
as a param.thing.